### PR TITLE
Allow millisecond timestamps for helper

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,20 +1,15 @@
 var Template = Package.templating.Template;
 
 Template.registerHelper('livestamp', function(date) {
-  var timestamp;
-  var timestring;
+  var time = moment(date);
 
-  if (_.isDate(date)){
-    timestamp = date.toISOString();
-  } else if (_.isString(date)){
-    timestamp = date;
-  } else if(_.isNumber(date)) {
-    timestamp = new Date(date).toISOString();
-  } else {
-    timestamp = new Date().toISOString();
+  // Fallback to current time if `date` is invalid.
+  if(!time.isValid()) {
+    time = moment();
   }
-  
-  timestring =  moment(timestamp).fromNow();
+
+  var timestamp = time.toISOString(),
+      timestring = time.fromNow();
   
   return new Spacebars.SafeString('<span class="livestamp" data-livestamp="'+ timestamp  +'">'+timestring+'</span>');
 });

--- a/helpers.js
+++ b/helpers.js
@@ -8,6 +8,8 @@ Template.registerHelper('livestamp', function(date) {
     timestamp = date.toISOString();
   } else if (_.isString(date)){
     timestamp = date;
+  } else if(_.isNumber(date)) {
+    timestamp = new Date(date).toISOString();
   } else {
     timestamp = new Date().toISOString();
   }


### PR DESCRIPTION
This patch allows the `livestamp` helper to take a number as the `date` parameter.

One further idea is to allow any value, and just feed it to `moment`, which can decide if it's a valid, parseable date value or not instead of manually checking.